### PR TITLE
Enhance chat look and markdown support

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,9 @@
 import os
+import re
 from flask import Flask, render_template, request, redirect, url_for, session
 from dotenv import load_dotenv
 from openai import OpenAI
+from markupsafe import Markup, escape
 
 load_dotenv()
 
@@ -9,6 +11,43 @@ app = Flask(__name__)
 app.secret_key = os.getenv("SECRET_KEY")
 if not app.secret_key:
     raise RuntimeError("SECRET_KEY environment variable is not set. Please set it to a strong, secure value.")
+
+# Simple markdown renderer for basic formatting
+@app.template_filter("markdown")
+def render_markdown(text: str) -> Markup:
+    """Convert a small subset of Markdown to HTML."""
+    text = escape(text)
+
+    # fenced code blocks
+    text = re.sub(r"```(.*?)```", r"<pre><code>\1</code></pre>", text, flags=re.S)
+    # inline code
+    text = re.sub(r"`([^`]+)`", r"<code>\1</code>", text)
+    # bold
+    text = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", text)
+    # emphasis
+    text = re.sub(r"\*(.+?)\*", r"<em>\1</em>", text)
+    text = re.sub(r"_(.+?)_", r"<em>\1</em>", text)
+
+    # simple bullet lists
+    lines = text.splitlines()
+    processed = []
+    in_list = False
+    for line in lines:
+        if re.match(r"^\s*[-*] ", line):
+            if not in_list:
+                processed.append("<ul>")
+                in_list = True
+            item = re.sub(r"^\s*[-*]\s+", "", line)
+            processed.append(f"<li>{item}</li>")
+        else:
+            if in_list:
+                processed.append("</ul>")
+                in_list = False
+            processed.append(line)
+    if in_list:
+        processed.append("</ul>")
+
+    return Markup("<br>".join(processed))
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 BEARER_TOKEN = os.getenv("BEARER_TOKEN")

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,24 +5,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Fastmail Chat</title>
     <style>
-        body { font-family: Arial, sans-serif; margin: 40px; }
-        .message { margin-bottom: 1em; }
-        .user { font-weight: bold; }
-        form { margin-top: 20px; }
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .chat-container { max-width: 700px; margin: 0 auto; }
+        .message { display: flex; margin-bottom: 10px; }
+        .bubble { padding: 10px; border-radius: 10px; max-width: 70%; }
+        .user { background: #dcf8c6; margin-left: auto; text-align: right; }
+        .assistant { background: #f1f0f0; margin-right: auto; }
+        form { display: flex; gap: 10px; margin-top: 20px; }
+        textarea { flex: 1; padding: 10px; }
     </style>
 </head>
 <body>
     <h1>Fastmail Chat</h1>
+    <div class="chat-container">
     {% for item in history %}
         <div class="message">
-            <div class="user">You:</div>
-            <div>{{ item.user }}</div>
-            <div class="user">Assistant:</div>
-            <div>{{ item.assistant }}</div>
+            <div class="bubble user">{{ item.user | e }}</div>
+        </div>
+        <div class="message">
+            <div class="bubble assistant">{{ item.assistant | markdown }}</div>
         </div>
     {% endfor %}
+    </div>
     <form method="post">
-        <textarea name="message" rows="3" cols="60" required></textarea><br>
+        <textarea name="message" rows="3" required></textarea>
         <button type="submit">Send</button>
         <button type="submit" name="action" value="clear">Clear Conversation</button>
     </form>


### PR DESCRIPTION
## Summary
- style chat bubbles left/right like modern chat apps
- display OpenAI Markdown output via custom filter

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842ee8f6ac0832792dc83b17d0db100