### PR TITLE
Fix clear conversation button

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -30,7 +30,7 @@
     <form method="post">
         <textarea name="message" rows="3" required></textarea>
         <button type="submit">Send</button>
-        <button type="submit" name="action" value="clear">Clear Conversation</button>
+        <button type="submit" name="action" value="clear" formnovalidate>Clear Conversation</button>
     </form>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow Clear Conversation button to submit the form even when message textarea is empty

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6842f1bec1308327bddfd3f5f36f974f