### PR TITLE
Clear textarea after sending message

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -95,11 +95,13 @@
 
                 const chat = document.querySelector('.chat-container');
                 const textarea = this.querySelector('textarea');
+                const textValue = textarea.value;
+                textarea.value = '';
                 const userMsg = document.createElement('div');
                 userMsg.className = 'message';
                 const userBubble = document.createElement('div');
                 userBubble.className = 'bubble user';
-                userBubble.textContent = textarea.value;
+                userBubble.textContent = textValue;
                 userMsg.appendChild(userBubble);
                 chat.appendChild(userMsg);
 


### PR DESCRIPTION
## Summary
- clear the message input after sending so it doesn't show previous text while waiting for a response

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684316f328fc832786ba139c7123bb90