### PR TITLE
Adjust control layout

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -18,12 +18,14 @@
             border: 1px solid #ccc;
             border-radius: 5px;
             font-size: 1rem;
+            height: 100px;
         }
         select {
             padding: 10px;
             border: 1px solid #ccc;
             border-radius: 5px;
             font-size: 1rem;
+            width: 100%;
         }
         button {
             border: none;
@@ -34,6 +36,23 @@
             align-items: center;
             gap: 5px;
             font-size: 1rem;
+        }
+        .controls {
+            display: flex;
+            flex-direction: column;
+            height: 100px;
+            gap: 10px;
+        }
+        .button-row {
+            display: flex;
+            gap: 10px;
+            flex: 1;
+        }
+        .button-row button {
+            flex: 1;
+        }
+        .controls select {
+            flex: 1;
         }
         .reasoning-icon { margin-left: 5px; cursor: pointer; }
         .reasoning-summary { display: none; background: #ffffff; border: 1px solid #ccc; border-radius: 5px; padding: 5px; margin-top: 5px; font-size: 0.9em; }
@@ -77,13 +96,17 @@
     </div>
     <form method="post">
         <textarea name="message" rows="3" required></textarea>
-        <select name="model">
-            {% for model in models %}
-            <option value="{{ model }}" {% if selected_model == model %}selected{% endif %}>{{ model }}</option>
-            {% endfor %}
-        </select>
-        <button type="submit" class="send-btn">✉️<span>Send</span><span class="spinner"></span></button>
-        <button type="submit" name="action" value="clear" formnovalidate class="clear-btn">🗑️<span>Clear</span></button>
+        <div class="controls">
+            <div class="button-row">
+                <button type="submit" class="send-btn">✉️<span>Send</span><span class="spinner"></span></button>
+                <button type="submit" name="action" value="clear" formnovalidate class="clear-btn">🗑️<span>Clear</span></button>
+            </div>
+            <select name="model">
+                {% for model in models %}
+                <option value="{{ model }}" {% if selected_model == model %}selected{% endif %}>{{ model }}</option>
+                {% endfor %}
+            </select>
+        </div>
     </form>
     <script>
         function toggleReasoning(el) {


### PR DESCRIPTION
## Summary
- place Send & Clear buttons in a row and move the model picker beneath them
- size the controls so they line up with the textarea

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68431c25ef6c8327b7675f926e1fc770