### PR TITLE
Ensure chat container auto-scrolls

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -172,5 +172,13 @@
             }
         });
     </script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const chat = document.querySelector('.chat-container');
+            if (chat) {
+                chat.scrollTop = chat.scrollHeight;
+            }
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- make chat scroll to the bottom after DOM ready

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68441df4c2808327bd9eff54e489c933