### PR TITLE
Add accessibility attributes

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -84,7 +84,7 @@
             <div class="bubble assistant">
                 {{ item.assistant | markdown }}
                 {% if item.reasoning and item.reasoning|length > 0 %}
-                <span class="reasoning-icon" onclick="toggleReasoning(this)">💭</span>
+                <span class="reasoning-icon" role="button" aria-label="Toggle reasoning" onclick="toggleReasoning(this)">💭</span>
                 <div class="reasoning-summary">
                     {% for text in item.reasoning %}
                         <p>{{ text | markdown }}</p>


### PR DESCRIPTION
## Summary
- improve accessibility of reasoning icon for screen readers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68441df5ccc88327b5fd5f6f9dbe6ec5