### PR TITLE
Implement SSE streaming for chat

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -175,16 +175,14 @@
             chat.scrollTop = chat.scrollHeight;
 
             try {
-                const response = await fetch('/', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-Requested-With': 'XMLHttpRequest'
-                    },
-                    body: JSON.stringify({ message: textValue, model: modelValue })
-                });
-                if (response.ok) {
-                    const data = await response.json();
+                const es = new EventSource('/stream?model=' + encodeURIComponent(modelValue) + '&message=' + encodeURIComponent(textValue));
+                es.onmessage = function(e) {
+                    assistBubble.textContent += e.data;
+                    chat.scrollTop = chat.scrollHeight;
+                };
+                es.addEventListener('end', function(ev) {
+                    es.close();
+                    const data = JSON.parse(ev.data);
                     assistBubble.innerHTML = data.assistant_html;
                     if (data.reasoning_html && data.reasoning_html.length) {
                         const icon = document.createElement('span');
@@ -201,12 +199,13 @@
                         assistBubble.appendChild(icon);
                         assistBubble.appendChild(summary);
                     }
-                } else {
-                    assistBubble.textContent = 'Error: ' + response.statusText;
-                }
+                    sendBtn.disabled = false;
+                    clearBtn.disabled = false;
+                    if (select) select.disabled = false;
+                    sendBtn.querySelector('.spinner').style.display = 'none';
+                });
             } catch (err) {
                 assistBubble.textContent = 'Error sending request';
-            } finally {
                 sendBtn.disabled = false;
                 clearBtn.disabled = false;
                 if (select) select.disabled = false;

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,13 @@
         body { font-family: Arial, sans-serif; margin: 20px; }
         .chat-container { max-width: 700px; margin: 0 auto; }
         .message { display: flex; margin-bottom: 10px; }
-        .bubble { padding: 10px; border-radius: 10px; max-width: 70%; }
+        .bubble {
+            padding: 10px;
+            border-radius: 10px;
+            max-width: 70%;
+            white-space: pre-wrap;
+            overflow-wrap: anywhere;
+        }
         .user { background: #dbe8ff; margin-left: auto; text-align: right; }
         .assistant { background: #f1f0f0; margin-right: auto; }
         form { display: flex; gap: 10px; margin-top: 20px; max-width: 700px; margin-left: auto; margin-right: auto; }


### PR DESCRIPTION
## Summary
- add SSE `/stream` endpoint for OpenAI streaming
- update frontend to use `EventSource` and display streamed tokens

## Testing
- `python -m py_compile app.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6848409ad0e4832784edf4dd32572a8e